### PR TITLE
Refactor/pdf upload

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,6 @@
 import os
 from typing import Any, Dict, cast
-from fastapi import FastAPI, File, UploadFile
+from fastapi import FastAPI, File, UploadFile, Form
 from app.rag.state import GraphState, QueryState
 from app.rag.workflow import pdf_graph, query_graph
 from langchain_core.messages import HumanMessage
@@ -11,14 +11,15 @@ session_store: Dict[str, dict[str, Any]] = {}
 
 
 @app.post("/upload")
-async def file_upload(file: UploadFile = File(...)):
+async def file_upload(file: UploadFile = File(...),
+                      pdf_id: str = Form(...)):
 
     # 1. 업로드 파일 저장
     temp_path = f"./temp_{file.filename}"
     with open(temp_path, "wb") as buffer:
         buffer.write(await file.read())
 
-    initial_state: GraphState = {"file_path": temp_path}
+    initial_state: GraphState = {"file_path": temp_path, "pdf_id": pdf_id}
     final_state = await pdf_graph.ainvoke(initial_state)
 
     # 2. 임시파일 삭제

--- a/app/rag/nodes.py
+++ b/app/rag/nodes.py
@@ -42,7 +42,7 @@ def create_vectorstore(state: GraphState) -> GraphState:
 
 # FAISS 디스크 저장
 def save_vectorstore(state: GraphState) -> GraphState:
-    pdf_id = state.get("pdf_id")
+    pdf_id = str(state.get("pdf_id"))
     if not pdf_id:
         raise ValueError("pdf_id가 state에 존재하지 않습니다.")
 
@@ -60,7 +60,7 @@ def save_vectorstore(state: GraphState) -> GraphState:
 
 # 1.Vectorstore 로드
 def load_vectorstore(state: QueryState) -> QueryState:
-    pdf_id = state.get("pdf_id")
+    pdf_id = str(state.get("pdf_id"))
     if not pdf_id:
         raise ValueError("pdf_id가 state에 없습니다.")
 

--- a/app/rag/nodes.py
+++ b/app/rag/nodes.py
@@ -21,8 +21,6 @@ MAX_HISTORY = 10
 
 # PDF 가져오기
 def load_pdf(state: GraphState) -> GraphState:
-    pdf_id = str(uuid4())
-    state["pdf_id"] = pdf_id
     loader = PyPDFLoader(state["file_path"])
     state["documents"] = loader.load()
     return state

--- a/app/rag/state.py
+++ b/app/rag/state.py
@@ -6,7 +6,7 @@ from langchain_core.messages import BaseMessage
 
 class GraphState(TypedDict):
     file_path: str
-    pdf_id: str
+    pdf_id: int
     documents: NotRequired[List]
     chunks: NotRequired[List]
     vectorstore: NotRequired[FAISS]
@@ -14,7 +14,7 @@ class GraphState(TypedDict):
 
 
 class QueryState(TypedDict):
-    pdf_id: str
+    pdf_id: int
     question: str
     vectorstore: NotRequired[FAISS]
     context: NotRequired[str]

--- a/app/rag/state.py
+++ b/app/rag/state.py
@@ -6,7 +6,7 @@ from langchain_core.messages import BaseMessage
 
 class GraphState(TypedDict):
     file_path: str
-    pdf_id: NotRequired[str]
+    pdf_id: str
     documents: NotRequired[List]
     chunks: NotRequired[List]
     vectorstore: NotRequired[FAISS]


### PR DESCRIPTION
세션 관리 코드 제거 및 SpringBoot전달 히스토리만 활용하도록 수정하였습니다.
- FastAPI의 session 관련 로직 삭제
- ChatIn 모델(pdf_id, question, history) 기반으로만 대화 처리
- history는 SpringBoot에서 Redis 관리 후 요청 시 전달하도록 변경