### PR TITLE
refactor(load_pdf): 업로드 파일 직접 로드 → URL 다운로드 후 임시 파일 로드로 변경

### DIFF
--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -1,0 +1,13 @@
+from typing import Dict, List
+from pydantic import BaseModel, Field
+
+
+class UploadIn(BaseModel):
+    pdf_id: int = Field(alias="productId")
+    fileUrl: str
+
+
+class ChatIn(BaseModel):
+    pdf_id: int = Field(alias="productId")
+    question: str
+    chatMessage: List[Dict[str, str]] = Field(default_factory=list, alias="messages")

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,6 @@
-import os
-from typing import Any, Dict, List, Optional
-from fastapi import FastAPI, File, UploadFile, Form
-from pydantic import BaseModel, Field
+from typing import List
+from fastapi import FastAPI
+from app.api.schemas import UploadIn, ChatIn
 from app.rag.state import GraphState, QueryState
 from app.rag.workflow import pdf_graph, query_graph
 from langchain_core.messages import HumanMessage, AIMessage, BaseMessage
@@ -9,12 +8,8 @@ from langchain_core.messages import HumanMessage, AIMessage, BaseMessage
 app = FastAPI(title="PDF RAG API")
 
 
-class uploadIn(BaseModel):
-    pdf_id: int = Field(alias="productId")
-    fileUrl: str
-
 @app.post("/upload")
-async def file_upload(request: uploadIn):
+async def file_upload(request: UploadIn):
     initial_state: GraphState = {"file_path": request.fileUrl, "pdf_id": request.pdf_id}
     final_state = await pdf_graph.ainvoke(initial_state)
 
@@ -24,11 +19,6 @@ async def file_upload(request: uploadIn):
         "store_path": final_state.get("store_path"),
     }
 
-
-class ChatIn(BaseModel):
-    pdf_id: int = Field(alias="productId")
-    question: str
-    chatMessage: List[Dict[str, str]] = Field(default_factory=list, alias="messages")
 
 @app.post("/chat")
 async def chat(request: ChatIn):

--- a/app/main.py
+++ b/app/main.py
@@ -7,27 +7,19 @@ from app.rag.workflow import pdf_graph, query_graph
 from langchain_core.messages import HumanMessage, AIMessage, BaseMessage
 
 app = FastAPI(title="PDF RAG API")
-# session 저장소
-session_store: Dict[str, dict[str, Any]] = {}
 
+
+class uploadIn(BaseModel):
+    pdf_id: int = Field(alias="productId")
+    fileUrl: str
 
 @app.post("/upload")
-async def file_upload(file: UploadFile = File(...),
-                      pdf_id: int = Form(...)):
-
-    # 1. 업로드 파일 저장
-    temp_path = f"./temp_{file.filename}"
-    with open(temp_path, "wb") as buffer:
-        buffer.write(await file.read())
-
-    initial_state: GraphState = {"file_path": temp_path, "pdf_id": pdf_id}
+async def file_upload(request: uploadIn):
+    initial_state: GraphState = {"file_path": request.fileUrl, "pdf_id": request.pdf_id}
     final_state = await pdf_graph.ainvoke(initial_state)
 
-    # 2. 임시파일 삭제
-    os.remove(temp_path)
-
     return {
-        "message": f"PDF {file.filename} uploaded successfully",
+        "message": f"PDF uploaded successfully",
         "pdf_id": final_state.get("pdf_id"),
         "store_path": final_state.get("store_path"),
     }

--- a/app/rag/state.py
+++ b/app/rag/state.py
@@ -7,6 +7,7 @@ from langchain_core.messages import BaseMessage
 class GraphState(TypedDict):
     file_path: str
     pdf_id: int
+    temp_path: NotRequired[str] 
     documents: NotRequired[List]
     chunks: NotRequired[List]
     vectorstore: NotRequired[FAISS]

--- a/app/rag/workflow.py
+++ b/app/rag/workflow.py
@@ -3,6 +3,7 @@ from app.rag.nodes import (
     create_vectorstore,
     decide_next,
     generate_answer,
+    fetch_pdf,
     load_pdf,
     load_vectorstore,
     retrieve_context,
@@ -15,12 +16,14 @@ from app.rag.state import GraphState, QueryState
 
 # PDF Workflow
 pdf_workflow = StateGraph(GraphState)
+pdf_workflow.add_node("fetch_pdf", fetch_pdf)
 pdf_workflow.add_node("load_pdf", load_pdf)
 pdf_workflow.add_node("split_chunks", split_chunks)
 pdf_workflow.add_node("create_vectorstore", create_vectorstore)
 pdf_workflow.add_node("save_vectorstore", save_vectorstore)
 
-pdf_workflow.set_entry_point("load_pdf")
+pdf_workflow.set_entry_point("fetch_pdf")
+pdf_workflow.add_edge("fetch_pdf", "load_pdf")
 pdf_workflow.add_edge("load_pdf", "split_chunks")
 pdf_workflow.add_edge("split_chunks", "create_vectorstore")
 pdf_workflow.add_edge("create_vectorstore", "save_vectorstore")


### PR DESCRIPTION
📄 Summary
>/upload API를 파일 직접 업로드 방식에서 파일 URL 기반 업로드 방식으로 변경했습니다.
>PDF 로드 과정에서 URL을 받아 임시 파일을 다운로드한 후 PyPDFLoader로 처리하도록 수정했습니다.